### PR TITLE
Added missing step to command line instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Here is how to build this project from the command line.
 git clone git@github.com:pyricau/CleanAndroidCode.git
 cd CleanAndroidCode
 git submodule init
+git submodule update
 # We use a custom version of Otto, see below
 cd otto
 mvn clean install -DskipTests


### PR DESCRIPTION
The command line instructions mentioned 'git submodule init' but was missing 'git submodule update'
